### PR TITLE
Add isolated static preview pages for OpenCATS site refresh

### DIFF
--- a/preview/home.html
+++ b/preview/home.html
@@ -1,0 +1,75 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>OpenCATS Homepage Refresh Preview</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header class="site-header">
+    <a class="brand" href="home.html" aria-label="OpenCATS preview home"><span class="brand-mark">OC</span><span>OpenCATS</span></a>
+    <nav class="nav" aria-label="Preview navigation">
+      <a href="home.html" aria-current="page">Home</a>
+      <a href="news.html">News</a>
+      <a href="https://documentation.opencats.org">Docs</a>
+      <a href="https://github.com/opencats/OpenCATS/releases/latest">Download</a>
+    </nav>
+  </header>
+  <main>
+    <section class="hero hero-grid" aria-labelledby="home-title">
+      <div class="hero-copy">
+        <p class="eyebrow">Open source applicant tracking</p>
+        <h1 id="home-title">Recruiting software that stays yours.</h1>
+        <p class="lede">OpenCATS is a community-maintained applicant tracking system for teams that need practical recruiting workflows, self-hosted control, and a project they can inspect, adapt, and improve.</p>
+        <div class="actions" aria-label="Primary actions">
+          <a class="button primary" href="https://github.com/opencats/OpenCATS/releases/latest">Download latest release</a>
+          <a class="button secondary" href="https://documentation.opencats.org">Read documentation</a>
+        </div>
+      </div>
+      <aside class="snapshot" aria-label="Project snapshot">
+        <p class="snapshot-title">Current project focus</p>
+        <div class="metric"><strong>v0.10.0</strong><span>Latest release previewed for administrators planning upgrades.</span></div>
+        <div class="metric"><strong>Self-hosted</strong><span>Own your candidate data and deployment path.</span></div>
+        <div class="metric"><strong>Community</strong><span>Support and roadmap discussion now happen on GitHub.</span></div>
+      </aside>
+    </section>
+
+    <section class="section" aria-labelledby="resources-title">
+      <div class="section-head">
+        <h2 id="resources-title">Start in the right place.</h2>
+        <p>Three quiet, obvious routes for visitors: get the software, learn how to run it, or join the project conversation.</p>
+      </div>
+      <div class="cards">
+        <article class="card"><span class="pill">Release</span><h3>Download OpenCATS</h3><p>Review the latest packaged release and notes before installing or upgrading a production instance.</p><a class="card-link" href="https://github.com/opencats/OpenCATS/releases/latest">Latest GitHub release →</a></article>
+        <article class="card"><span class="pill">Guide</span><h3>Documentation</h3><p>Installation, upgrade, and administration guidance for evaluating and maintaining OpenCATS.</p><a class="card-link" href="https://documentation.opencats.org">Open documentation →</a></article>
+        <article class="card"><span class="pill">Discuss</span><h3>Community support</h3><p>Ask questions, compare deployments, and coordinate improvements with maintainers and users.</p><a class="card-link" href="https://github.com/opencats/OpenCATS/discussions">GitHub Discussions →</a></article>
+      </div>
+    </section>
+
+    <section class="section why" aria-labelledby="why-title">
+      <div><p class="eyebrow">Why OpenCATS</p><h2 id="why-title">Built for teams that value control.</h2></div>
+      <div class="why-list">
+        <article class="card"><h3>Open source</h3><p>Inspect the code, run it on your infrastructure, and make changes when your recruiting workflow requires them.</p></article>
+        <article class="card"><h3>Recruiting-focused</h3><p>Candidate, job order, resume, and activity tracking remain centered on the work recruiters do every day.</p></article>
+        <article class="card"><h3>Community maintained</h3><p>The project is sustained by users and contributors who keep security, releases, and support visible.</p></article>
+      </div>
+    </section>
+
+    <section class="section" aria-labelledby="security-title">
+      <div class="callout">
+        <div><p class="eyebrow">Security and support history</p><h2 id="security-title">Keep current, and use the archive when needed.</h2><p>Review published security advisories for upgrade decisions. Older forum content remains available as a legacy archive, while active support continues on GitHub Discussions.</p></div>
+        <div class="actions"><a class="button primary" href="https://github.com/opencats/OpenCATS/security/advisories">Security advisories</a><a class="button secondary" href="/forums/">Legacy forum archive</a></div>
+      </div>
+    </section>
+  </main>
+  <footer class="site-footer">
+    <div class="footer-grid">
+      <div class="footer-col"><a class="brand" href="home.html"><span class="brand-mark">OC</span><span>OpenCATS</span></a><p class="small">A static design preview only. Production templates have not been changed.</p></div>
+      <div class="footer-col"><strong>Project</strong><a href="https://github.com/opencats/OpenCATS/releases/latest">Releases</a><a href="https://github.com/opencats/OpenCATS">Source code</a></div>
+      <div class="footer-col"><strong>Learn</strong><a href="https://documentation.opencats.org">Documentation</a><a href="news.html">News preview</a></div>
+      <div class="footer-col"><strong>Community</strong><a href="https://github.com/opencats/OpenCATS/discussions">Discussions</a><a href="/forums/">Forum archive</a></div>
+    </div>
+  </footer>
+</body>
+</html>

--- a/preview/index.html
+++ b/preview/index.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>OpenCATS Website Refresh Preview Index</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header class="site-header">
+    <a class="brand" href="index.html" aria-label="OpenCATS preview index"><span class="brand-mark">OC</span><span>OpenCATS previews</span></a>
+    <nav class="nav" aria-label="Preview navigation">
+      <a href="index.html" aria-current="page">Preview index</a>
+      <a href="home.html">Home</a>
+      <a href="news.html">News</a>
+    </nav>
+  </header>
+  <main>
+    <section class="review-panel" aria-labelledby="preview-title">
+      <p class="eyebrow">Design review only</p>
+      <h1 id="preview-title">Static previews for a warmer OpenCATS website refresh.</h1>
+      <p class="lede">These files are isolated in <code>preview/</code> so reviewers can evaluate the visual direction without changing the production homepage, layouts, includes, navigation data, or main stylesheet.</p>
+      <ul class="review-list" aria-label="Preview pages">
+        <li><a href="home.html">Homepage preview <span>Hero, cards, security callout, footer</span></a></li>
+        <li><a href="news.html">News page preview <span>Secondary page heading and update cards</span></a></li>
+      </ul>
+    </section>
+    <section class="section" aria-labelledby="review-title">
+      <div class="cards">
+        <article class="card"><span class="pill">How to review</span><h2 id="review-title">Check real viewport sizes.</h2><p>Review the concept at desktop width around 1440px, tablet width around 768px, and mobile width around 390px. Confirm hierarchy, spacing, link clarity, and whether the calmer OpenCATS green feels right.</p></article>
+        <article class="card"><span class="pill">Scope</span><h2>Production is unchanged.</h2><p>This preview intentionally avoids editing <code>index.html</code>, <code>_layouts/</code>, <code>_includes/</code>, <code>_data/nav.yml</code>, and <code>css/main.css</code>. It is plain HTML and CSS with no build step.</p></article>
+        <article class="card"><span class="pill">Direction</span><h2>Inspired, not cloned.</h2><p>The visual language borrows the calm editorial pacing, large type, cream surfaces, and restrained green accents requested for the refresh while using OpenCATS-specific content and destinations.</p></article>
+      </div>
+    </section>
+  </main>
+  <footer class="site-footer"><p class="small">Local paths for review: <a href="index.html">/preview/</a>, <a href="home.html">/preview/home.html</a>, and <a href="news.html">/preview/news.html</a>.</p></footer>
+</body>
+</html>

--- a/preview/news.html
+++ b/preview/news.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>OpenCATS News Page Refresh Preview</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header class="site-header">
+    <a class="brand" href="home.html" aria-label="OpenCATS preview home"><span class="brand-mark">OC</span><span>OpenCATS</span></a>
+    <nav class="nav" aria-label="Preview navigation">
+      <a href="home.html">Home</a><a href="news.html" aria-current="page">News</a><a href="https://documentation.opencats.org">Docs</a><a href="https://github.com/opencats/OpenCATS/discussions">Discuss</a>
+    </nav>
+  </header>
+  <main>
+    <section class="page-hero" aria-labelledby="news-title">
+      <p class="eyebrow">Project updates</p>
+      <h1 id="news-title">News for OpenCATS admins and contributors.</h1>
+      <p class="lede">A calmer secondary-page treatment for releases, security updates, and community notices. These cards use topics from existing OpenCATS posts.</p>
+    </section>
+    <section class="section" aria-label="News posts">
+      <div class="news-grid">
+        <article class="card"><p class="date">June 23, 2026</p><h3>OpenCATS v0.10.0 released</h3><p>The latest release is available from GitHub, with installation documentation and community discussion linked for upgrade planning.</p><a class="card-link" href="https://github.com/opencats/OpenCATS/releases/latest">Review release →</a></article>
+        <article class="card"><p class="date">January 30, 2023</p><h3>Security release and vulnerability news</h3><p>Version 0.9.7 addressed findings from a security audit and encouraged administrators to update promptly.</p><a class="card-link" href="https://github.com/opencats/OpenCATS/security/advisories">Security advisories →</a></article>
+        <article class="card"><p class="date">July 1, 2019</p><h3>0.9.4 security update</h3><p>A focused security update resolved an XXE issue and directed users to fixed releases and support channels.</p><a class="card-link" href="https://github.com/opencats/OpenCATS/discussions">Discuss support →</a></article>
+        <article class="card"><p class="date">May 12, 2017</p><h3>May project update</h3><p>Community newsletters can be presented as concise summaries with clearer routes to documentation, downloads, and contribution.</p><a class="card-link" href="home.html">See homepage system →</a></article>
+      </div>
+    </section>
+  </main>
+  <footer class="site-footer">
+    <div class="footer-grid">
+      <div class="footer-col"><a class="brand" href="home.html"><span class="brand-mark">OC</span><span>OpenCATS</span></a><p class="small">News preview only; production news layouts remain untouched.</p></div>
+      <div class="footer-col"><strong>Project</strong><a href="https://github.com/opencats/OpenCATS/releases/latest">Releases</a><a href="https://github.com/opencats/OpenCATS/security/advisories">Security</a></div>
+      <div class="footer-col"><strong>Learn</strong><a href="https://documentation.opencats.org">Documentation</a><a href="home.html">Home preview</a></div>
+      <div class="footer-col"><strong>Community</strong><a href="https://github.com/opencats/OpenCATS/discussions">Discussions</a><a href="/forums/">Forum archive</a></div>
+    </div>
+  </footer>
+</body>
+</html>

--- a/preview/styles.css
+++ b/preview/styles.css
@@ -1,0 +1,105 @@
+:root {
+  --bg: #f7f1e6;
+  --bg-soft: #fbf7ef;
+  --ink: #17211b;
+  --muted: #5e675f;
+  --green: #2f6f4e;
+  --green-deep: #1f5138;
+  --sage: #dce7d8;
+  --line: rgba(23, 33, 27, .14);
+  --card: rgba(255, 252, 246, .78);
+  --shadow: 0 22px 70px rgba(31, 43, 35, .10);
+  --radius-lg: 34px;
+  --radius-md: 22px;
+  --radius-sm: 14px;
+  --space: clamp(1.25rem, 2vw, 2rem);
+  --max: 1180px;
+  --font: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; }
+body {
+  margin: 0;
+  min-width: 320px;
+  background:
+    radial-gradient(circle at 10% 4%, rgba(47, 111, 78, .16), transparent 30rem),
+    radial-gradient(circle at 92% 18%, rgba(220, 231, 216, .88), transparent 28rem),
+    var(--bg);
+  color: var(--ink);
+  font-family: var(--font);
+  line-height: 1.55;
+}
+a { color: inherit; text-decoration-thickness: .08em; text-underline-offset: .18em; }
+a:hover { color: var(--green-deep); }
+:focus-visible { outline: 3px solid rgba(47, 111, 78, .5); outline-offset: 4px; border-radius: 8px; }
+
+.site-header, main, .site-footer { width: min(calc(100% - 2rem), var(--max)); margin-inline: auto; }
+.site-header { display: flex; align-items: center; justify-content: space-between; gap: 1rem; padding: 1.2rem 0; }
+.brand { display: inline-flex; align-items: center; gap: .7rem; font-weight: 800; letter-spacing: -.04em; text-decoration: none; font-size: 1.15rem; }
+.brand-mark { display: grid; place-items: center; width: 2.35rem; height: 2.35rem; border-radius: 50%; background: var(--green); color: var(--bg-soft); font-size: .9rem; box-shadow: inset 0 -8px 16px rgba(0,0,0,.12); }
+.nav { display: flex; align-items: center; gap: .4rem; flex-wrap: wrap; justify-content: flex-end; }
+.nav a { padding: .62rem .85rem; border-radius: 999px; color: var(--muted); text-decoration: none; font-size: .95rem; }
+.nav a:hover, .nav a[aria-current="page"] { background: rgba(47, 111, 78, .10); color: var(--ink); }
+
+.hero, .page-hero, .review-panel { margin-top: clamp(2rem, 6vw, 5rem); }
+.eyebrow { color: var(--green-deep); font-weight: 750; text-transform: uppercase; letter-spacing: .14em; font-size: .78rem; }
+h1, h2, h3 { line-height: .98; letter-spacing: -.065em; margin: 0; }
+h1 { font-size: clamp(3.4rem, 10vw, 8.6rem); max-width: 12ch; }
+h2 { font-size: clamp(2.2rem, 5vw, 4.8rem); }
+h3 { font-size: clamp(1.25rem, 2vw, 1.7rem); }
+p { color: var(--muted); margin: 0; }
+.lede { font-size: clamp(1.15rem, 2.2vw, 1.55rem); max-width: 46rem; color: #38433b; }
+.hero-grid { display: grid; grid-template-columns: minmax(0, 1.1fr) minmax(280px, .55fr); gap: clamp(2rem, 6vw, 5rem); align-items: end; }
+.hero-copy { display: grid; gap: 1.4rem; }
+.actions { display: flex; gap: .8rem; flex-wrap: wrap; margin-top: .4rem; }
+.button { display: inline-flex; align-items: center; justify-content: center; min-height: 3rem; padding: .82rem 1.1rem; border: 1px solid var(--line); border-radius: 999px; text-decoration: none; font-weight: 750; transition: transform .18s ease, background .18s ease; }
+.button:hover { transform: translateY(-2px); }
+.button.primary { background: var(--green); color: white; border-color: transparent; }
+.button.secondary { background: rgba(255,255,255,.48); }
+.snapshot { border: 1px solid var(--line); border-radius: var(--radius-lg); background: rgba(255,255,255,.42); padding: 1.25rem; box-shadow: var(--shadow); }
+.snapshot-title { color: var(--ink); font-weight: 800; margin-bottom: 1rem; }
+.metric { display: grid; gap: .2rem; padding: 1rem 0; border-top: 1px solid var(--line); }
+.metric strong { font-size: 1.7rem; letter-spacing: -.04em; }
+.metric span { color: var(--muted); }
+
+.section { padding: clamp(4rem, 8vw, 7rem) 0 0; }
+.section-head { display: flex; justify-content: space-between; gap: 1.5rem; align-items: end; margin-bottom: 1.25rem; }
+.section-head p { max-width: 34rem; }
+.cards { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 1rem; }
+.card, .callout, .review-panel { background: var(--card); border: 1px solid var(--line); border-radius: var(--radius-md); padding: clamp(1.2rem, 2.4vw, 2rem); box-shadow: 0 12px 40px rgba(31,43,35,.06); }
+.card { min-height: 15rem; display: flex; flex-direction: column; gap: 1rem; }
+.card p { flex: 1; }
+.card-link { font-weight: 800; color: var(--green-deep); }
+.pill { align-self: flex-start; border: 1px solid var(--line); border-radius: 999px; padding: .28rem .62rem; color: var(--green-deep); font-size: .8rem; font-weight: 750; }
+.why { display: grid; grid-template-columns: .85fr 1fr; gap: 1rem; }
+.why-list { display: grid; gap: 1rem; }
+.callout { display: grid; grid-template-columns: 1fr auto; align-items: center; gap: 1rem; background: #edf3e8; }
+.news-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 1rem; margin-top: 2rem; }
+.date { color: var(--green-deep); font-weight: 800; }
+
+.site-footer { margin-top: clamp(4rem, 8vw, 7rem); padding: 2rem 0 3rem; border-top: 1px solid var(--line); }
+.footer-grid { display: grid; grid-template-columns: 1.2fr repeat(3, 1fr); gap: 1.5rem; }
+.footer-col { display: grid; gap: .5rem; align-content: start; }
+.footer-col a { color: var(--muted); text-decoration: none; }
+.footer-col a:hover { color: var(--green-deep); text-decoration: underline; }
+.small { font-size: .92rem; color: var(--muted); }
+
+.review-list { display: grid; gap: .8rem; margin: 1.5rem 0 0; padding: 0; list-style: none; }
+.review-list a { display: flex; justify-content: space-between; gap: 1rem; padding: 1rem; border: 1px solid var(--line); border-radius: var(--radius-sm); background: rgba(255,255,255,.42); text-decoration: none; font-weight: 800; }
+.review-list span { color: var(--muted); font-weight: 500; }
+
+@media (max-width: 820px) {
+  .hero-grid, .why, .callout, .footer-grid { grid-template-columns: 1fr; }
+  .cards, .news-grid { grid-template-columns: 1fr 1fr; }
+  .section-head { display: grid; align-items: start; }
+}
+@media (max-width: 560px) {
+  .site-header { align-items: flex-start; flex-direction: column; }
+  .nav { justify-content: flex-start; }
+  .nav a { padding-left: .7rem; padding-right: .7rem; }
+  h1 { font-size: clamp(3rem, 17vw, 4.8rem); }
+  .cards, .news-grid { grid-template-columns: 1fr; }
+  .card { min-height: 0; }
+  .review-list a { display: grid; }
+}


### PR DESCRIPTION
### Motivation
- Provide an isolated, reviewable preview of a proposed OpenCATS website refresh inspired by an editorial, calm direction so reviewers can evaluate visuals without touching production templates. 
- Replace any earlier rough preview with a cleaner, more polished static implementation that demonstrates homepage and secondary-page treatments.

### Description
- Add a self-contained `preview/` set: `preview/index.html` (landing + how-to-review guidance), `preview/home.html` (polished homepage concept), `preview/news.html` (secondary news listing), and `preview/styles.css` (shared design tokens and responsive styles). 
- The HTML uses semantic landmarks (`header`, `nav`, `main`, `section`, `footer`), one `<h1>` per page, accessible labels, real OpenCATS destinations, and no external fonts or JavaScript. 
- The stylesheet uses CSS custom properties for color/spacing/typography, a responsive grid/card system, hover and `:focus-visible` states, and avoids a build step so pages are static and self-contained. 
- The preview intentionally does not modify production artifacts such as `index.html`, `_layouts/`, `_includes/`, `_data/nav.yml`, or `css/main.css`.

### Testing
- Ran `git status --short` and file checks for `preview/index.html`, `preview/home.html`, `preview/news.html`, and `preview/styles.css` which confirmed the files exist. 
- Parsed the three HTML files with Python's `html.parser` which completed successfully and reported file sizes. 
- Served the repo with `python3 -m http.server` and verified HTTP `200` responses for `/preview/`, `/preview/home.html`, `/preview/news.html`, and `/preview/styles.css` via `curl`. 
- Attempted `bundle exec jekyll build` and Playwright screenshots: `jekyll`/Bundler was not available in the environment and Playwright browser download failed with a `403 Domain forbidden`, so those checks could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d4f4ba9388322aa79971a948cdff2)