### PR TITLE
Update community support links to OpenCATS subreddit

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,8 +65,8 @@ redirect_from:
     </div>
     <div class="callout-card">
       <h3>Join the project</h3>
-      <p>Use the support page to find current GitHub Discussions and the locked legacy forum archive.</p>
-      <a class="text-link" href="/support/">Visit support</a>
+      <p>Join the OpenCATS subreddit for peer-to-peer user support, troubleshooting discussions, and community conversations.</p>
+      <a class="text-link" href="https://reddit.com/r/openCATS">Visit the community forum</a>
     </div>
   </div>
 </section>

--- a/support.html
+++ b/support.html
@@ -11,13 +11,13 @@ canonical_url: /support/
     <div>
       <p class="eyebrow">Support</p>
       <h1>Get help with OpenCATS.</h1>
-      <p class="lead">For current questions, project updates, release conversations, and community support, use GitHub Discussions. The legacy forum remains available as a locked archive for older answers and historical context.</p>
+      <p class="lead">For peer-to-peer user support, troubleshooting discussions, release conversations, and community questions, use the OpenCATS subreddit. The legacy forum remains available as a locked archive for older answers and historical context.</p>
     </div>
     <div class="feature-grid">
       <article class="feature-card">
-        <h2>GitHub Discussions</h2>
-        <p>Use the live community discussion area for new support questions, installation help, release feedback, and project conversations.</p>
-        <a class="text-link" href="https://github.com/opencats/OpenCATS/discussions">Open GitHub Discussions</a>
+        <h2>Community forum</h2>
+        <p>Use the OpenCATS subreddit for peer-to-peer support, installation help, troubleshooting discussions, release feedback, and user conversations.</p>
+        <a class="text-link" href="https://reddit.com/r/openCATS">Open the OpenCATS subreddit</a>
       </article>
       <article class="feature-card">
         <h2>Legacy support forum archive</h2>


### PR DESCRIPTION
### Motivation
- Direct users to the active peer-to-peer community forum on Reddit (`https://reddit.com/r/openCATS`) instead of pointing to GitHub Discussions so support/discussion links reflect the current community location.

### Description
- Update `index.html` callout copy and link to point to the OpenCATS subreddit and update `support.html` lead text, community card heading, and link to reference the subreddit while retaining the legacy forum archive link.

### Testing
- Ran `git diff --check` and `bundle exec jekyll build` which completed successfully, and an attempted Playwright screenshot step failed because the Playwright browser download was blocked with a 403 from the CDN.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d289a47208322be1b09a593fcb70b)